### PR TITLE
Add cookie consent system and CookiePolicy page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import ProtectedRoute from "./components/ProtectedRoute/ProtectedRoute";
 import LoginModal from "./components/LoginModal/LoginModal";
 import RegisterModal from "./components/RegisterModal/RegisterModal";
 import CookiePolicy from "./pages/CookiePolicy/CookiePolicy";
+import CookieBanner from "./components/CookieBanner/CookieBanner";
 
 // Scrolls to top when route changes
 function ScrollToTop() {
@@ -53,6 +54,7 @@ function App() {
           <Route path="/booking" element={<BookingPage />} />
           <Route path="/booking/:movieTitle" element={<BookingPage />} />
 
+          {/* confirmation route without bookingUrl */}
           <Route path="/confirmation" element={<ConfirmationPage />} />
 
           {/* Existing route for already booked confirmation */}
@@ -79,6 +81,8 @@ function App() {
 
       {/* REGISTER MODAL */}
       <RegisterModal open={registerOpen} onRequestClose={() => setRegisterOpen(false)} />
+
+      <CookieBanner /> 
 
       <Footer />
     </>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import MyPages from "./pages/MyPages/MyPages";
 import ProtectedRoute from "./components/ProtectedRoute/ProtectedRoute";
 import LoginModal from "./components/LoginModal/LoginModal";
 import RegisterModal from "./components/RegisterModal/RegisterModal";
+import CookiePolicy from "./pages/CookiePolicy/CookiePolicy";
 
 // Scrolls to top when route changes
 function ScrollToTop() {
@@ -46,12 +47,12 @@ function App() {
           <Route path="/om-oss" element={<About />} />
           <Route path="/shop" element={<Shop />} />
           <Route path="/upptack" element={<Discover />} />
+          <Route path="/cookies" element={<CookiePolicy />} />
 
           {/* Booking and confirmation routes */}
           <Route path="/booking" element={<BookingPage />} />
           <Route path="/booking/:movieTitle" element={<BookingPage />} />
 
-          {/* ✅ NEW: confirmation route without bookingUrl */}
           <Route path="/confirmation" element={<ConfirmationPage />} />
 
           {/* Existing route for already booked confirmation */}

--- a/frontend/src/components/CookieBanner/CookieBanner.css
+++ b/frontend/src/components/CookieBanner/CookieBanner.css
@@ -1,0 +1,121 @@
+.cookiebanner {
+    position: fixed;
+    inset-inline: 0;
+    bottom: 0;
+    z-index: 9998;
+    padding: 12px 16px 16px;
+    background: radial-gradient(circle at top left, #26263b 0%, #12121d 60%, #0a0a12 100%);
+    box-shadow: 0 -8px 30px rgba(0, 0, 0, 0.75);
+  }
+  
+  .cookiebanner-inner {
+    max-width: 960px;
+    margin: 0 auto;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(15, 15, 28, 0.94);
+    padding: 16px 18px;
+    display: flex;
+    gap: 18px;
+    align-items: center;
+  }
+  
+  .cookiebanner-text {
+    flex: 1 1 auto;
+  }
+  
+  .cookiebanner-title {
+    text-align: left;
+    margin: 0 0 6px;
+    font-size: 1rem;
+    font-weight: 700;
+    color: #ffffff;
+  }
+  
+  .cookiebanner-body {
+    text-align: left;
+    margin: 0 0 6px;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    color: #e3e4ff;
+    opacity: 0.95;
+  }
+  
+  .cookiebanner-linktext {
+    text-align: left;
+    margin: 0;
+    font-size: 0.85rem;
+    color: #cfd1ff;
+  }
+  
+  .cookiebanner-link {
+    color: var(--red-primary, #c41230);
+    font-weight: 500;
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+  }
+  
+  .cookiebanner-link:hover {
+    opacity: 0.9;
+  }
+  
+  .cookiebanner-actions {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+    flex-shrink: 0;
+  }
+  
+  .cookiebanner-btn {
+    min-width: 150px;
+    padding: 0.6rem 1rem;
+    border-radius: 9px;
+    border: none;
+    font-size: 0.9rem;
+    font-weight: 400;
+    cursor: pointer;
+    letter-spacing: 0.03em;
+    transition: transform 0.06s ease, filter 0.18s ease, background 0.2s ease,
+      box-shadow 0.2s ease;
+  }
+  
+  .cookiebanner-btn.primary {
+    background: var(--red-primary, #c41230);
+    color: #fff;
+    box-shadow:
+      0 6px 14px rgba(0, 0, 0, 0.25),
+      inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  }
+  
+  .cookiebanner-btn.secondary {
+    background: #29293a;
+    color: #f3f3ff;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+  }
+  
+  .cookiebanner-btn:hover {
+    filter: brightness(1.05);
+  }
+  
+  .cookiebanner-btn:active {
+    transform: translateY(1px);
+  }
+  
+  /* Mobile */
+  @media (max-width: 720px) {
+    .cookiebanner-inner {
+      flex-direction: column;
+      align-items: stretch;
+      padding: 14px 12px;
+    }
+  
+    .cookiebanner-actions {
+      width: 100%;
+      flex-direction: column;
+    }
+  
+    .cookiebanner-btn {
+      width: 100%;
+      min-width: 0;
+    }
+  }

--- a/frontend/src/components/CookieBanner/CookieBanner.tsx
+++ b/frontend/src/components/CookieBanner/CookieBanner.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import "./CookieBanner.css";
+// component to show cookie consent banner
+const COOKIE_CONSENT_KEY = "cookieConsent";
+// types of consent values that can be stored
+type ConsentValue = "necessary" | "all";
+
+export default function CookieBanner() {
+  const [visible, setVisible] = useState(false);
+    // check local storage for existing consent on component mount
+  useEffect(() => {
+    const stored = localStorage.getItem(COOKIE_CONSENT_KEY);
+    if (!stored) {
+      setVisible(true); // show banner if no consent found
+    }
+  }, []);
+  // handle user choice and store in local storage
+  function handleChoice(value: ConsentValue) { 
+    localStorage.setItem(COOKIE_CONSENT_KEY, value); 
+    setVisible(false);
+  }
+
+  if (!visible) return null; // do not render if not visible
+
+  return (
+    <section
+      className="cookiebanner"
+      role="dialog"
+      aria-modal="false"
+      aria-label="Information om cookies"
+    >
+      <div className="cookiebanner-inner">
+        <div className="cookiebanner-text">
+          <h2 className="cookiebanner-title">Vi använder cookies</h2>
+          <p className="cookiebanner-body">
+            Vi använder nödvändiga tekniska cookies för att sidan och inloggning ska fungera.
+            Framöver vill vi även kunna använda cookies för statistik, som i sin tur kan
+            användas som underlag för marknadsföring. Du kan välja att endast tillåta
+            nödvändiga cookies.
+          </p>
+          <p className="cookiebanner-linktext">
+            Läs mer i vår{" "}
+            <a href="/cookies" className="cookiebanner-link">
+              cookiepolicy
+            </a>
+            .
+          </p>
+        </div>
+
+        <div className="cookiebanner-actions">
+          <button
+            type="button"
+            className="cookiebanner-btn secondary"
+            onClick={() => handleChoice("necessary")}
+          >
+            Endast nödvändiga
+          </button>
+          <button
+            type="button"
+            className="cookiebanner-btn primary"
+            onClick={() => handleChoice("all")}
+          >
+            Acceptera alla
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import "./Footer.css";
 
 export default function Footer() {
@@ -14,6 +15,7 @@ export default function Footer() {
   <a href="/om-oss">Om oss</a>
   <a href="/shop">Vår kiosk</a>
   <a href="/upptack">Veckans film</a>
+  <Link to="/cookies">Cookiepolicy</Link>
 </address>
 
     </footer>

--- a/frontend/src/pages/CookiePolicy/CookiePolicy.css
+++ b/frontend/src/pages/CookiePolicy/CookiePolicy.css
@@ -2,7 +2,8 @@
     width: 60%;
     max-width: 1100px;
     margin: 0 auto;
-    padding: 48px 16px 64px;
+    padding: 48px 16px 16px;
+    padding-bottom: 2vh !important;
     color: var(--text-light);
     text-align: left;
   }
@@ -36,19 +37,19 @@
   }
   
   .cookiepolicy-section {
-    margin: 32px 0;
-    line-height: 1.7;
+    margin: 30px 0;
+    line-height: 1.6;
     font-size: 1rem;
   }
   
   .cookiepolicy-section p {
-    margin: 0 0 12px;
+    margin: 0 0 10px;
   }
   
   .cookiepolicy-subtitle {
     font-size: 22px;
-    font-weight: 700;
-    margin: 0 0 10px;
+    font-weight: 600;
+    margin: 0 0 1px;
   }
   
   .cookiepolicy-list {
@@ -63,7 +64,7 @@
   
   @media (max-width: 800px) {
     .cookiepolicy {
-      width: 90%;
+      width: 70%;
       padding: 32px 12px 48px;
     }
   

--- a/frontend/src/pages/CookiePolicy/CookiePolicy.css
+++ b/frontend/src/pages/CookiePolicy/CookiePolicy.css
@@ -3,9 +3,9 @@
     max-width: 1100px;
     margin: 0 auto;
     padding: 48px 16px 16px;
-    padding-bottom: 2vh !important;
     color: var(--text-light);
     text-align: left;
+    margin-top: 40px;
   }
   
   .cookiepolicy-card {

--- a/frontend/src/pages/CookiePolicy/CookiePolicy.css
+++ b/frontend/src/pages/CookiePolicy/CookiePolicy.css
@@ -1,0 +1,77 @@
+.cookiepolicy {
+    width: 60%;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 48px 16px 64px;
+    color: var(--text-light);
+    text-align: left;
+  }
+  
+  .cookiepolicy-card {
+    max-width: 780px;
+  }
+  
+  .cookiepolicy-eyebrow {
+    margin: 0 0 6px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    opacity: 0.75;
+  }
+  
+  .cookiepolicy-title {
+    margin: 0 0 12px;
+    font-weight: 800;
+    font-size: 32px;
+    position: relative;
+  }
+  
+  .cookiepolicy-title::after {
+    content: "";
+    display: block;
+    width: 72px;
+    height: 3px;
+    background: var(--red-primary);
+    border-radius: 2px;
+    margin-top: 12px;
+  }
+  
+  .cookiepolicy-section {
+    margin: 32px 0;
+    line-height: 1.7;
+    font-size: 1rem;
+  }
+  
+  .cookiepolicy-section p {
+    margin: 0 0 12px;
+  }
+  
+  .cookiepolicy-subtitle {
+    font-size: 22px;
+    font-weight: 700;
+    margin: 0 0 10px;
+  }
+  
+  .cookiepolicy-list {
+    list-style: disc;
+    padding-left: 1.5rem;
+    margin: 12px 0 0;
+  }
+  
+  .cookiepolicy-list li {
+    margin-bottom: 6px;
+  }
+  
+  @media (max-width: 800px) {
+    .cookiepolicy {
+      width: 90%;
+      padding: 32px 12px 48px;
+    }
+  
+    .cookiepolicy-card {
+      max-width: 100%;
+    }
+  
+    .cookiepolicy-title {
+      font-size: 26px;
+    }
+  }

--- a/frontend/src/pages/CookiePolicy/CookiePolicy.tsx
+++ b/frontend/src/pages/CookiePolicy/CookiePolicy.tsx
@@ -1,0 +1,18 @@
+import "./CookiePolicy.css";
+          <p>
+            Framöver vill vi även kunna använda statistikcookies för att förstå hur
+            vår webbplats används. Statistiken kan i nästa steg användas som underlag
+            för marknadsföring. Du ska alltid kunna välja bort dessa.
+          </p>
+          <p>
+            Just nu använder vi inte några statistik- eller marknadsföringscookies.
+            När vi börjar göra det kommer vi:
+          </p>
+          <p>
+            Du kan alltid välja att endast använda nödvändiga cookies. I vår cookie-banner
+            kan du välja mellan att acceptera alla cookies eller endast tekniskt nödvändiga.
+          </p>
+          <p>
+            Om du har frågor om vår hantering av cookies kan du kontakta oss via
+            uppgifterna på sidan <em>Om oss</em>.
+          </p>

--- a/frontend/src/pages/CookiePolicy/CookiePolicy.tsx
+++ b/frontend/src/pages/CookiePolicy/CookiePolicy.tsx
@@ -12,50 +12,52 @@ export default function CookiePolicy() {
 
         <section className="cookiepolicy-section">
           <p>
-            På Filmvisarna använder vi främst tekniska, nödvändiga cookies för att webbplatsen
-            ska fungera på ett säkert och stabilt sätt. Dessa cookies behövs exempelvis för
-            inloggning, säkerhet och grundläggande funktioner.
+            Filmvisarna använder ingen extern spårning och vi sätter inga cookies för
+            marknadsföring eller statistik. För att webbplatsen ska fungera använder vi istället
+            webbläsarens localStorage för att spara grundläggande information.
           </p>
           <p>
-            Du kan även välja om du vill tillåta statistikcookies. Statistiska cookies används
-            för analys och är alltid frivilliga. Om du inte ger samtycke aktiveras inga
-            statistikcookies.
+            Denna lagring är tekniskt nödvändig, till exempel för att du ska kunna vara inloggad
+            och för att vi ska komma ihåg om du har gjort ett val i vår cookie-banner.
           </p>
         </section>
 
         <section className="cookiepolicy-section">
-          <h2 className="cookiepolicy-subtitle">Nödvändiga cookies</h2>
-          <p>Dessa cookies krävs för att webbplatsen ska fungera.</p>
+          <h2 className="cookiepolicy-subtitle">Nödvändig lagring</h2>
+          <p>
+            Vi sparar endast sådan information som behövs för att webbplatsen ska fungera på ett
+            säkert och stabilt sätt. Följande värden kan sparas i din webbläsare:
+          </p>
 
           <ul className="cookiepolicy-list">
             <li>
-              <strong>session_id</strong> – håller dig inloggad under ditt besök.
+              <strong>authUser</strong> – håller reda på att du är inloggad.
             </li>
             <li>
-              <strong>csrf_token</strong> – skyddar formulär och inloggning.
+              <strong>authToken</strong> –
+              används för att validera din session under besöket.
             </li>
             <li>
-              <strong>preferenser</strong> – kan spara exempelvis språkval.
+              <strong>cookieConsent</strong> – sparar ditt val i cookiebannern
+              (t.ex. ”acceptera” eller ”endast nödvändiga”).
             </li>
           </ul>
         </section>
 
         <section className="cookiepolicy-section">
-          <h2 className="cookiepolicy-subtitle">Statistikcookies </h2>
+          <h2 className="cookiepolicy-subtitle">Statistik och tredjepart</h2>
           <p>
-            Statistikcookies används endast om du ger samtycke i vår cookie-banner. Om du inte
-            accepterar statistikcookies sätts inga sådana cookies.
+            Filmvisarna använder inga statistikverktyg, inga analyscookies och ingen
+            marknadsföringsspårning. Ingen information delas med tredje part.
           </p>
         </section>
 
         <section className="cookiepolicy-section">
           <h2 className="cookiepolicy-subtitle">Dina val</h2>
           <p>
-            I cookie-bannern kan du välja om du vill tillåta statistikcookies eller inte. Det
-            är alltid lika enkelt att avvisa som att acceptera.
-          </p>
-          <p>
-            Du kan när som helst ändra ditt val genom att rensa cookies i din webbläsare.
+            I cookie-bannern kan du välja om du vill tillåta frivillig lagring eller endast
+            nödvändig lagring. Du kan när som helst ändra ditt val genom att rensa
+            localStorage i din webbläsare.
           </p>
         </section>
       </article>

--- a/frontend/src/pages/CookiePolicy/CookiePolicy.tsx
+++ b/frontend/src/pages/CookiePolicy/CookiePolicy.tsx
@@ -5,63 +5,57 @@ export default function CookiePolicy() {
     <main className="cookiepolicy">
       <article className="cookiepolicy-card" aria-labelledby="cookiepolicy-heading">
         <p className="cookiepolicy-eyebrow">Information</p>
+
         <h1 id="cookiepolicy-heading" className="cookiepolicy-title">
           Cookiepolicy för Filmvisarna
         </h1>
 
         <section className="cookiepolicy-section">
           <p>
-            På Filmvisarna använder vi främst tekniska cookies för att sidan ska fungera,
-            till exempel för inloggning och säkerhet.
+            På Filmvisarna använder vi främst tekniska, nödvändiga cookies för att webbplatsen
+            ska fungera på ett säkert och stabilt sätt. Dessa cookies behövs exempelvis för
+            inloggning, säkerhet och grundläggande funktioner.
           </p>
           <p>
-            Framöver vill vi även kunna använda statistikcookies för att förstå hur
-            vår webbplats används. Statistiken kan i nästa steg användas som underlag
-            för marknadsföring. Du ska alltid kunna välja bort dessa.
+            Du kan även välja om du vill tillåta statistikcookies. Statistiska cookies används
+            för analys och är alltid frivilliga. Om du inte ger samtycke aktiveras inga
+            statistikcookies.
           </p>
         </section>
 
         <section className="cookiepolicy-section">
-          <h2 className="cookiepolicy-subtitle">Tekniska cookies (nödvändiga)</h2>
-          <p>
-            Dessa cookies behövs för att webbplatsen ska fungera och kan inte stängas av
-            i våra system.
-          </p>
+          <h2 className="cookiepolicy-subtitle">Nödvändiga cookies</h2>
+          <p>Dessa cookies krävs för att webbplatsen ska fungera.</p>
+
           <ul className="cookiepolicy-list">
             <li>
               <strong>session_id</strong> – håller dig inloggad under ditt besök.
             </li>
             <li>
-              <strong>csrf_token</strong> – hjälper oss att skydda formulär och inloggning.
+              <strong>csrf_token</strong> – skyddar formulär och inloggning.
             </li>
             <li>
-              <strong>preferenser</strong> – kan spara grundläggande inställningar, t.ex. språk.
+              <strong>preferenser</strong> – kan spara exempelvis språkval.
             </li>
           </ul>
         </section>
 
         <section className="cookiepolicy-section">
-          <h2 className="cookiepolicy-subtitle">Statistikcookies (frivilliga)</h2>
+          <h2 className="cookiepolicy-subtitle">Statistikcookies </h2>
           <p>
-            Just nu använder vi inte några statistik- eller marknadsföringscookies.
-            När vi börjar göra det kommer vi:
+            Statistikcookies används endast om du ger samtycke i vår cookie-banner. Om du inte
+            accepterar statistikcookies sätts inga sådana cookies.
           </p>
-          <ul className="cookiepolicy-list">
-            <li>fråga om ditt samtycke innan de aktiveras,</li>
-            <li>låta dig välja endast nödvändiga cookies,</li>
-            <li>visa tydlig information om vad statistiken används till.</li>
-          </ul>
         </section>
 
         <section className="cookiepolicy-section">
           <h2 className="cookiepolicy-subtitle">Dina val</h2>
           <p>
-            Du kan alltid välja att endast använda nödvändiga cookies. I vår cookie-banner
-            kan du välja mellan att acceptera alla cookies eller endast tekniskt nödvändiga.
+            I cookie-bannern kan du välja om du vill tillåta statistikcookies eller inte. Det
+            är alltid lika enkelt att avvisa som att acceptera.
           </p>
           <p>
-            Om du har frågor om vår hantering av cookies kan du kontakta oss via
-            uppgifterna på sidan <em>Om oss</em>.
+            Du kan när som helst ändra ditt val genom att rensa cookies i din webbläsare.
           </p>
         </section>
       </article>

--- a/frontend/src/pages/CookiePolicy/CookiePolicy.tsx
+++ b/frontend/src/pages/CookiePolicy/CookiePolicy.tsx
@@ -1,13 +1,60 @@
 import "./CookiePolicy.css";
+
+export default function CookiePolicy() {
+  return (
+    <main className="cookiepolicy">
+      <article className="cookiepolicy-card" aria-labelledby="cookiepolicy-heading">
+        <p className="cookiepolicy-eyebrow">Information</p>
+        <h1 id="cookiepolicy-heading" className="cookiepolicy-title">
+          Cookiepolicy för Filmvisarna
+        </h1>
+
+        <section className="cookiepolicy-section">
+          <p>
+            På Filmvisarna använder vi främst tekniska cookies för att sidan ska fungera,
+            till exempel för inloggning och säkerhet.
+          </p>
           <p>
             Framöver vill vi även kunna använda statistikcookies för att förstå hur
             vår webbplats används. Statistiken kan i nästa steg användas som underlag
             för marknadsföring. Du ska alltid kunna välja bort dessa.
           </p>
+        </section>
+
+        <section className="cookiepolicy-section">
+          <h2 className="cookiepolicy-subtitle">Tekniska cookies (nödvändiga)</h2>
+          <p>
+            Dessa cookies behövs för att webbplatsen ska fungera och kan inte stängas av
+            i våra system.
+          </p>
+          <ul className="cookiepolicy-list">
+            <li>
+              <strong>session_id</strong> – håller dig inloggad under ditt besök.
+            </li>
+            <li>
+              <strong>csrf_token</strong> – hjälper oss att skydda formulär och inloggning.
+            </li>
+            <li>
+              <strong>preferenser</strong> – kan spara grundläggande inställningar, t.ex. språk.
+            </li>
+          </ul>
+        </section>
+
+        <section className="cookiepolicy-section">
+          <h2 className="cookiepolicy-subtitle">Statistikcookies (frivilliga)</h2>
           <p>
             Just nu använder vi inte några statistik- eller marknadsföringscookies.
             När vi börjar göra det kommer vi:
           </p>
+          <ul className="cookiepolicy-list">
+            <li>fråga om ditt samtycke innan de aktiveras,</li>
+            <li>låta dig välja endast nödvändiga cookies,</li>
+            <li>visa tydlig information om vad statistiken används till.</li>
+          </ul>
+        </section>
+
+        <section className="cookiepolicy-section">
+          <h2 className="cookiepolicy-subtitle">Dina val</h2>
           <p>
             Du kan alltid välja att endast använda nödvändiga cookies. I vår cookie-banner
             kan du välja mellan att acceptera alla cookies eller endast tekniskt nödvändiga.
@@ -16,3 +63,8 @@ import "./CookiePolicy.css";
             Om du har frågor om vår hantering av cookies kan du kontakta oss via
             uppgifterna på sidan <em>Om oss</em>.
           </p>
+        </section>
+      </article>
+    </main>
+  );
+}


### PR DESCRIPTION
Add a simple cookie banner and a CookiePolicy page.
Users are told about the technical cookies we use and can choose if they want to allow statistics cookies.