### PR TITLE
Remove unused bestRow variable in auditorium components

### DIFF
--- a/frontend/src/components/Auditorium/AuditoriumOne.tsx
+++ b/frontend/src/components/Auditorium/AuditoriumOne.tsx
@@ -123,7 +123,7 @@ export default function AuditoriumOne({ screeningId }: AuditoriumProps) {
 
     const rowOrder = ["E", "D", "F", "C", "G", "B", "H", "A"];
     let bestGroup: Seat[] = [];
-    let bestRow = "";
+    
 
     for (const row of rowOrder) {
       const rowSeats = rowsMap[row];
@@ -179,7 +179,7 @@ export default function AuditoriumOne({ screeningId }: AuditoriumProps) {
       // Found a valid closest group
       if (closestGroup.length > 0) {
         bestGroup = closestGroup;
-        bestRow = row;
+        
         break; // stop at first suitable row (closest to center)
       }
     }

--- a/frontend/src/components/Auditorium/AuditoriumTwo.tsx
+++ b/frontend/src/components/Auditorium/AuditoriumTwo.tsx
@@ -122,7 +122,7 @@ export default function AuditoriumTwo({ screeningId }: AuditoriumProps) {
     const rowOrder = ["C", "D", "B", "E", "A", "F"];
 
     let bestGroup: Seat[] = [];
-    let bestRow = "";
+    
 
     for (const row of rowOrder) {
       const rowSeats = rowsMap[row];
@@ -174,7 +174,7 @@ export default function AuditoriumTwo({ screeningId }: AuditoriumProps) {
 
       if (closestGroup.length > 0) {
         bestGroup = closestGroup;
-        bestRow = row;
+      
         break;
       }
     }


### PR DESCRIPTION
Eliminated the unused 'bestRow' variable from AuditoriumOne and AuditoriumTwo components to clean up the code and improve maintainability.